### PR TITLE
fix(ci): use branch head SHA for PR multidev build detection

### DIFF
--- a/.github/workflows/test-pantheon.yml
+++ b/.github/workflows/test-pantheon.yml
@@ -58,12 +58,17 @@ jobs:
             PR_NUM=${{ github.event.pull_request.number }}
             ENV_NAME="pr-${PR_NUM}"
             BASE_URL="https://pr-${PR_NUM}-${PANTHEON_SITE_NAME}.pantheonsite.io"
+            # For PRs, github.sha is GitHub's synthetic merge commit — Pantheon never
+            # sees it. The branch head SHA is what Pantheon actually checks out and builds.
+            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
           else
             ENV_NAME="dev"
             BASE_URL="https://dev-${PANTHEON_SITE_NAME}.pantheonsite.io"
+            COMMIT_SHA="${{ github.sha }}"
           fi
           echo "env_name=${ENV_NAME}" >> $GITHUB_OUTPUT
           echo "base_url=${BASE_URL}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Setup PHP (required for Terminus)
         uses: shivammathur/setup-php@v2
@@ -101,8 +106,12 @@ jobs:
 
           echo "✓ Authenticated with Pantheon API"
 
-          # Get current commit SHA
-          COMMIT_SHA="${{ github.sha }}"
+          # Commit SHA resolved in the Determine environment step.
+          # For PRs: github.event.pull_request.head.sha (branch head — what Pantheon builds)
+          # For pushes: github.sha (the pushed commit)
+          # NOTE: github.sha on pull_request events is GitHub's synthetic merge commit,
+          # which Pantheon never sees. Using it here was the original bug.
+          COMMIT_SHA="${{ steps.env.outputs.commit_sha }}"
           echo "Looking for build matching commit: ${COMMIT_SHA:0:7}"
 
           # Monitor Pantheon workflow status via Terminus CLI
@@ -127,6 +136,15 @@ jobs:
               echo "This may indicate the build hasn't started yet, retrying..."
               sleep $SLEEP_TIME
               continue
+            fi
+
+            # On first attempt, log the raw response to confirm API shape and SHA format.
+            # This helps diagnose mismatches between github.event.pull_request.head.sha
+            # and whatever commit field Pantheon exposes in the build list.
+            if [ $ATTEMPT -eq 1 ]; then
+              echo "--- API response (attempt 1, for diagnostics) ---"
+              echo "$BUILDS_RESPONSE" | jq '.'
+              echo "-------------------------------------------------"
             fi
 
             # Find build matching this commit SHA


### PR DESCRIPTION
## Problem

The CI workflow's "Wait for Pantheon build and deployment to complete" step timed out on **every single PR**, causing all tests (unit + E2E) to be skipped.

Root cause: the wait step used \`github.sha\` to match a build in the Pantheon build list API. On \`pull_request\` events, \`github.sha\` is GitHub's **synthetic merge commit** — a commit GitHub computes internally to preview what a merged result would look like. This SHA is never pushed to any remote and Pantheon never sees it.

Pantheon's GitHub app checks out the actual PR branch head and builds from that. The correct SHA is \`github.event.pull_request.head.sha\`.

The SHA mismatch meant \`select(.commit == "\$COMMIT_SHA")\` never matched anything, the loop ran all 60 iterations (10 minutes), then exited 1 — skipping unit tests, Playwright install, E2E tests, everything.

## Fix

- In the \`Determine environment\` step, set \`COMMIT_SHA\` based on event type:
  - \`pull_request\`: \`github.event.pull_request.head.sha\` (branch head — what Pantheon builds)
  - \`push\`: \`github.sha\` (the pushed commit — correct for non-PR events)
- Output \`commit_sha\` alongside \`env_name\` and \`base_url\`
- Wait step reads \`steps.env.outputs.commit_sha\` instead of \`github.sha\`
- Added diagnostic logging of the raw API response on attempt 1 so we can confirm the fix worked and see the exact field/SHA format Pantheon returns

## What was not changed

- \`continue-on-error\` behavior (intentional)
- API endpoint, auth mechanism, or polling logic
- Any other workflow steps

## Testing

This PR itself is the test. The Pantheon GitHub app will create a multidev for this PR. The workflow should now find the build using \`github.event.pull_request.head.sha\` and proceed to run tests against the multidev. The attempt-1 API response dump in the logs will also confirm the correct JSON shape.

fixes #16 